### PR TITLE
fix(pkg): add `types` field to the `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "sideEffects": false,
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/index.mjs",
     "require": "./dist/index.cjs"
   },


### PR DESCRIPTION
This is needed if `"moduleResolution": "nodenext"` and `"type": "module"` were set.