### PR TITLE
feat: universal `env` proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ const { isCI } = require('std-env')
 
 Available exports:
 
+- `env`
+- `nodeENV`
 - `hasTTY`
 - `hasWindow`
 - `isCI`

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,39 @@
+const _envShim = Object.create(null);
+
+const _getEnv = (useShim?: boolean) =>
+  globalThis.__env__ ||
+  globalThis.process?.env ||
+  (useShim ? _envShim : globalThis);
+
+export const env = new Proxy(_envShim, {
+  get(_, prop) {
+    const env = _getEnv();
+    return env[prop as any] ?? _envShim[prop];
+  },
+  has(_, prop) {
+    const env = _getEnv();
+    return prop in env || prop in _envShim;
+  },
+  set(_, prop, value) {
+    const env = _getEnv(true);
+    env[prop as any] = value;
+    return true;
+  },
+  deleteProperty(_, prop) {
+    if (!prop) {
+      return false;
+    }
+    const env = _getEnv(true);
+    delete env[prop as any];
+    return true;
+  },
+  ownKeys() {
+    const env = _getEnv();
+    return Object.keys(env);
+  },
+});
+
+export const nodeENV =
+  (typeof process !== "undefined" && process.env && process.env.NODE_ENV) ||
+  env.NODE_ENV ||
+  "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,35 +1,34 @@
 import { detectProvider, ProviderName } from "./providers";
+import { env, nodeENV } from "./env";
+export { env, nodeENV } from "./env";
 
 export type { ProviderName, ProviderInfo } from "./providers";
 
-const processShim: typeof process =
+const _process: typeof process =
   typeof process !== "undefined" ? process : ({} as typeof process);
-const envShim = processShim.env || ({} as typeof process.env);
+const envShim = _process.env || ({} as typeof process.env);
 const providerInfo = detectProvider(envShim);
 
-const nodeENV =
-  (typeof process !== "undefined" && process.env && process.env.NODE_ENV) || "";
-
 /** Value of process.platform */
-export const platform = processShim.platform;
+export const platform = _process.platform;
 
 /** Current provider name */
 export const provider: ProviderName = providerInfo.name;
 
 /** Detect if `CI` environment variable is set or a provider CI detected */
-export const isCI = toBoolean(envShim.CI) || providerInfo.ci !== false;
+export const isCI = toBoolean(env.CI) || providerInfo.ci !== false;
 
 /** Detect if stdout.TTY is available */
-export const hasTTY = toBoolean(processShim.stdout && processShim.stdout.isTTY);
+export const hasTTY = toBoolean(_process.stdout && _process.stdout.isTTY);
 
 /** Detect if global `window` object is available */
 export const hasWindow = typeof window !== "undefined";
 
 /** Detect if `DEBUG` environment variable is set */
-export const isDebug = toBoolean(envShim.DEBUG);
+export const isDebug = toBoolean(env.DEBUG);
 
 /** Detect if `NODE_ENV` environment variable is `test` */
-export const isTest = nodeENV === "test" || toBoolean(envShim.TEST);
+export const isTest = nodeENV === "test" || toBoolean(env.TEST);
 
 /** Detect if `NODE_ENV` environment variable is `production` */
 export const isProduction = nodeENV === "production";
@@ -38,8 +37,7 @@ export const isProduction = nodeENV === "production";
 export const isDevelopment = nodeENV === "dev" || nodeENV === "development";
 
 /** Detect if MINIMAL environment variable is set, running in CI or test or TTY is unavailable */
-export const isMinimal =
-  toBoolean(envShim.MINIMAL) || isCI || isTest || !hasTTY;
+export const isMinimal = toBoolean(env.MINIMAL) || isCI || isTest || !hasTTY;
 
 /** Detect if process.platform is Windows */
 export const isWindows = /^win/i.test(platform);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5,6 +5,8 @@ describe("std-env", () => {
   it("has expected exports", () => {
     expect(Object.keys(stdEnv)).toMatchInlineSnapshot(`
       [
+        "env",
+        "nodeENV",
         "platform",
         "provider",
         "isCI",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Based on unenv (https://github.com/unjs/unenv/pull/125), expose a global `env` proxy object that is compatible with `process.env` and also platforms that don't have it.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
