### PR TITLE
feat: detect `stackblitz` using `process.versions.webcontainer`

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -7,7 +7,7 @@ import { _process } from "./process";
 export const platform = _process.platform || "";
 
 /** Current provider info */
-export const providerInfo = detectProvider(env);
+export const providerInfo = detectProvider(env, _process);
 export const provider: ProviderName = providerInfo.name;
 
 /** Detect if `CI` environment variable is set or a provider CI detected */

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -102,6 +102,7 @@ export type ProviderInfo = { name: ProviderName; [meta: string]: any };
 
 export function detectProvider(
   env: Record<string, string | undefined>,
+  ctx: { versions?: Record<string, string> } = {},
 ): ProviderInfo {
   // Based on env
   for (const provider of providers) {
@@ -115,7 +116,7 @@ export function detectProvider(
   }
 
   // Stackblitz / Webcontainer
-  if (env.SHELL && env.SHELL === "/bin/jsh") {
+  if (env.SHELL === "/bin/jsh" || ctx.versions?.webcontainer) {
     return {
       name: "stackblitz",
       ci: false,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Improve stackblitz/webcontainer environment detection based on `process.versions.webcontainer`.

PS: I really hope someday soon Stackblitz standard environment variables to make us able to detect running environment easier..

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
