### PR TITLE
feat: improve hasTTY detection

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -10,7 +10,7 @@ export const isCI = toBoolean(env.CI) || providerInfo.ci !== false;
 
 /** Detect if stdout.TTY is available */
 export const hasTTY = toBoolean(
-  globalThis.process?.stdout && globalThis.process?.stdout.isTTY,
+  globalThis.process?.stdout && (globalThis.process.stdout.isTTY || globalThis.process.stdout._type === 'tty'),
 );
 
 /** Detect if global `window` object is available */


### PR DESCRIPTION
Context: WSL2 Alpine with zsh

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I'm using WSL2 Alpine zsh, `hasTTY` isn't detected so things like `isColorSupported` is false.
From my stdout dump there's a flag: `_type='tty'` that could be used.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
