### PR TITLE
fix(isColorSupported): inverted condition for `TERM=dumb`

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -45,7 +45,7 @@ export const isColorSupported =
   !toBoolean(env.NO_COLOR) &&
   (toBoolean(env.FORCE_COLOR) ||
     (isWindows && !(env.TERM === "dumb")) ||
-    (hasTTY && env.TERM && !(env.TERM !== "dumb")) ||
+    (hasTTY && env.TERM && env.TERM !== "dumb") ||
     isCI);
 
 /** Node.js versions */

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -44,8 +44,7 @@ export const isMacOS = /^darwin/i.test(platform);
 export const isColorSupported =
   !toBoolean(env.NO_COLOR) &&
   (toBoolean(env.FORCE_COLOR) ||
-    (isWindows && !(env.TERM === "dumb")) ||
-    (hasTTY && env.TERM && env.TERM !== "dumb") ||
+    ((hasTTY || isWindows) && env.TERM !== "dumb") ||
     isCI);
 
 /** Node.js versions */


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Currently our condition checks for !!TERM=dumb, which means `isColorSupported` will be set to true for terminal that doesn't support color, and vice-versa, isColorSupported is false for supported terminals,  
this corrects the behavior.

Ref: https://www.npmjs.com/package/color-support

**Note**: Should it be a breaking change?

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
