### PR TITLE
feat: check `MODE` variable for isDevelopment and isProduction flags

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -22,11 +22,11 @@ export const isDebug = toBoolean(env.DEBUG);
 /** Detect if `NODE_ENV` environment variable is `test` */
 export const isTest = nodeENV === "test" || toBoolean(env.TEST);
 
-/** Detect if `NODE_ENV` environment variable is `production` */
-export const isProduction = nodeENV === "production";
+/** Detect if `NODE_ENV` or `MODE` environment variable is `production` */
+export const isProduction = nodeENV === "production" || env.MODE === "production";
 
-/** Detect if `NODE_ENV` environment variable is `dev` or `development` */
-export const isDevelopment = nodeENV === "dev" || nodeENV === "development";
+/** Detect if `NODE_ENV` environment variable is `dev` or `development`, or if `MODE` environment variable is `development` */
+export const isDevelopment = nodeENV === "dev" || nodeENV === "development" || env.MODE === "development";
 
 /** Detect if MINIMAL environment variable is set, running in CI or test or TTY is unavailable */
 export const isMinimal = toBoolean(env.MINIMAL) || isCI || isTest || !hasTTY;


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
Currently n/a, can open an issue as well if you want me to.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
Utilize the `MODE` environment variable to check if we are in development or production in addition to other checks from before. 

<!-- Why is this change required? What problem does it solve? -->
The `MODE` environment variable is used in Cloudflare Workers, as well as in [Vite](https://vitejs.dev/guide/env-and-mode#modes) to differentiate running in development or production. 

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
