### PR TITLE
fix(providers): detect `CODESANDBOX_HOST` 

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -100,6 +100,7 @@ const providers: InternalProvider[] = [
   ["VERCEL", "VERCEL_ENV", { ci: false }],
   ["APPCENTER", "APPCENTER_BUILD_ID"],
   ["CODESANDBOX", "CODESANDBOX_SSE", { ci: false }],
+  ["CODESANDBOX", "CODESANDBOX_HOST", { ci: false }],
   ["STACKBLITZ"],
   ["STORMKIT"],
   ["CLEAVR"],


### PR DESCRIPTION
`CODESANDBOX_SSE` is not always present in CSB boxes