### PR TITLE
feat: detect cloudflare workers build ci

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -15,6 +15,7 @@ export type ProviderName =
   | "circle"
   | "cirrus"
   | "cloudflare_pages"
+  | "cloudflare_workers"
   | "codebuild"
   | "codefresh"
   | "drone"
@@ -70,6 +71,7 @@ const providers: InternalProvider[] = [
   ["CIRCLE", "CIRCLECI"],
   ["CIRRUS", "CIRRUS_CI"],
   ["CLOUDFLARE_PAGES", "CF_PAGES", { ci: true }],
+  ["CLOUDFLARE_WORKERS", "WORKERS_CI", { ci: true }],
   ["CODEBUILD", "CODEBUILD_BUILD_ARN"],
   ["CODEFRESH", "CF_BUILD_ID"],
   ["DRONE"],


### PR DESCRIPTION
Detect [cloudflare worker builds](https://developers.cloudflare.com/workers/ci-cd/builds/) CI using `WORKERS_CI` env (manual test, shows value is `1`)