### PR TITLE
Add Cloud Run to the known providers

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -16,6 +16,8 @@ export type ProviderName =
   | "cirrus"
   | "cloudflare_pages"
   | "cloudflare_workers"
+  | "cloudrun"
+  | "cloudrun_job"
   | "codebuild"
   | "codefresh"
   | "drone"
@@ -72,6 +74,8 @@ const providers: InternalProvider[] = [
   ["CIRRUS", "CIRRUS_CI"],
   ["CLOUDFLARE_PAGES", "CF_PAGES", { ci: true }],
   ["CLOUDFLARE_WORKERS", "WORKERS_CI", { ci: true }],
+  ["CLOUDRUN", "K_SERVICE"],
+  ["CLOUDRUN_JOB", "CLOUD_RUN_JOB"],
   ["CODEBUILD", "CODEBUILD_BUILD_ARN"],
   ["CODEFRESH", "CF_BUILD_ID"],
   ["DRONE"],


### PR DESCRIPTION
Add Cloud Run and Cloud Run jobs to the list of known providers. Using the env vars documented in:
https://cloud.google.com/run/docs/container-contract#jobs-env-vars

resolves #160 
