### PR TITLE
feat: detect `DENO_DEPLOY` for deno deploy EA

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -113,6 +113,7 @@ const providers: InternalProvider[] = [
   ["CODESPHERE", "CODESPHERE_APP_ID", { ci: true }],
   ["RAILWAY", "RAILWAY_PROJECT_ID"],
   ["RAILWAY", "RAILWAY_SERVICE_ID"],
+  ["DENO-DEPLOY", "DENO_DEPLOY"],
   ["DENO-DEPLOY", "DENO_DEPLOYMENT_ID"],
   ["FIREBASE_APP_HOSTING", "FIREBASE_APP_HOSTING", { ci: true }],
 ];


### PR DESCRIPTION
Previously we were only detecting `DENO_DEPLOYMENT_ID` at runtime.

`DENO_DEPLOY=1` is available in both the new EA CI and the runtime and should be checked additionally.

(thanks @lucacasonato for the info ❤️ !)