### PR TITLE
fix(agents): skip kiro detection in IDE terminals with TTY

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,6 +1,6 @@
 // Note to AI Agents: Check @AGENTS.md for instructions on how to self-verify.
 
-import { env } from "./env.ts";
+import { env, process } from "./env.ts";
 
 /**
  * Represents the name of an AI coding agent.
@@ -46,8 +46,8 @@ const agents: InternalAgent[] = [
   ["devin", [envMatcher("EDITOR", /devin/)]],
   // ✅ Verified by cursor (can be detected using CURSOR_AGENT, CURSOR_TRACE_ID, CURSOR_SANDBOX)
   ["cursor", ["CURSOR_AGENT"]],
-  // ✅ Verified by kiro (can be detected using TERM_PROGRAM)
-  ["kiro", [envMatcher("TERM_PROGRAM", /kiro/)]],
+  // ✅ Verified by kiro (TERM_PROGRAM + non-interactive stdout; IDE terminals have TTY)
+  ["kiro", [() => envMatcher("TERM_PROGRAM", /kiro/)() && !process.stdout?.isTTY]],
 ];
 
 function envMatcher(envKey: string, regex: RegExp) {

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -1,5 +1,6 @@
 import { expect, it, describe, vi, beforeEach, afterEach } from "vitest";
 import { detectAgent } from "../src/agents.ts";
+import { process } from "../src/env.ts";
 
 // All env vars that agent detection may check
 const agentEnvKeys = [
@@ -64,9 +65,23 @@ describe("detectAgent", () => {
   });
 
   describe("regex env var checks", () => {
-    it("detects kiro via TERM_PROGRAM matching /kiro/", () => {
+    it("detects kiro via TERM_PROGRAM matching /kiro/ without TTY", () => {
       vi.stubEnv("TERM_PROGRAM", "kiro-terminal");
       expect(detectAgent()).toEqual({ name: "kiro" });
+    });
+
+    it("does not detect kiro IDE terminal when stdout is a TTY", () => {
+      vi.stubEnv("TERM_PROGRAM", "kiro-terminal");
+      const stdout = process.stdout ?? {};
+      Object.defineProperty(stdout, "isTTY", {
+        configurable: true,
+        get: () => true,
+      });
+      Object.defineProperty(process, "stdout", {
+        configurable: true,
+        value: stdout,
+      });
+      expect(detectAgent()).toEqual({});
     });
 
     it("does not detect kiro when TERM_PROGRAM does not match", () => {


### PR DESCRIPTION
## Summary

Fixes #185

Kiro IDE integrated terminals set `TERM_PROGRAM` the same way as kiro CLI, so manual terminal sessions were incorrectly detected as agent runs.

Per maintainer suggestion in the issue thread, kiro detection now also requires a non-TTY stdout. This keeps kiro CLI/agent subprocess detection while excluding interactive IDE terminals.

## Test plan

- [x] `pnpm lint:fix`
- [x] `pnpm test`
- [x] Added regression test for kiro + TTY → not detected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of kiro agent detection to eliminate false positives occurring in IDE terminal environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/std-env/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->