### PR TITLE
feat: add `env` support for Cloudflare worker, using conditional import

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -1,10 +1,5 @@
 import { defineBuildConfig } from "obuild/config";
 
 export default defineBuildConfig({
-  entries: [{ type: "bundle", input: "src/index.ts" }],
-  hooks: {
-    rolldownOutput(cfg) {
-      cfg.minify = true;
-    },
-  },
+  entries: [{ type: "transform", input: "src", minify: true }],
 });

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint": "oxlint . && oxfmt",
     "lint:fix": "oxlint --fix . && oxfmt",
     "prepack": "obuild",
-    "release": "pnpm test && pnpm build && changelogen --release --publish && git push --follow-tags",
+    "release": "pnpm test && pnpm build && changelogen --release && pnpm publish --access public && git push --follow-tags",
     "test": "pnpm lint && pnpm typecheck && vitest run --coverage",
     "typecheck": "tsgo --noEmit"
   },

--- a/package.json
+++ b/package.json
@@ -11,8 +11,26 @@
   "sideEffects": false,
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
+  "imports": {
+    "#env": {
+      "workerd": "./src/env.workerd.ts",
+      "default": "./src/env.ts"
+    }
+  },
   "exports": {
     ".": "./dist/index.mjs"
+  },
+  "publishConfig": {
+    "imports": {
+      "#env": {
+        "workerd": {
+          "default": "./dist/env.workerd.mjs",
+          "types": "./dist/env.workerd.d.mts"
+        },
+        "default": "./dist/env.mjs",
+        "types": "./dist/env.d.mts"
+      }
+    }
   },
   "scripts": {
     "build": "obuild",
@@ -25,6 +43,7 @@
     "typecheck": "tsgo --noEmit"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260619.1",
     "@types/node": "^25.2.3",
     "@typescript/native-preview": "^7.0.0-dev.20260217.1",
     "@vitest/coverage-v8": "^4.0.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260619.1
+        version: 4.20260619.1
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3
@@ -88,6 +91,9 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@cloudflare/workers-types@4.20260619.1':
+    resolution: {integrity: sha512-bprsNzG0DapQPFwU2AvQlQ6FUO7Y4bKWaPBzLNI7nBSqlHsK0P62xx2NaNT6i/htzAgQspKZm1D32y0RxofrRQ==}
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -1381,6 +1387,8 @@ snapshots:
       '@babel/helper-validator-identifier': 8.0.0-rc.1
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@cloudflare/workers-types@4.20260619.1': {}
 
   '@emnapi/core@1.8.1':
     dependencies:

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,6 +1,6 @@
 // Note to AI Agents: Check @AGENTS.md for instructions on how to self-verify.
 
-import { env } from "./env.ts";
+import { env } from "#env";
 
 /**
  * Represents the name of an AI coding agent.

--- a/src/env.workerd.ts
+++ b/src/env.workerd.ts
@@ -1,0 +1,17 @@
+import { env } from "cloudflare:workers";
+
+export { env };
+
+/**
+ * Runtime-agnostic reference to the `process` global.
+ *
+ * Resolves to `globalThis.process` when available, otherwise a minimal shim containing only `env`.
+ */
+export const process: { env: {} } = { env };
+
+/**
+ * Current value of the `NODE_ENV` environment variable (or static value if replaced during build).
+ *
+ * If `NODE_ENV` is not set, this will be undefined.
+ */
+export const nodeENV: string | undefined = undefined;

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,5 +1,5 @@
 import { providerInfo } from "./providers.ts";
-import { env, nodeENV, process } from "./env.ts";
+import { env, nodeENV, process } from "#env";
 
 /** Value of process.platform */
 export const platform: string = process.platform || "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export {
   detectAgent,
 } from "./agents.ts";
 
-export { env, process, nodeENV } from "./env.ts";
+export { env, process, nodeENV } from "#env";
 
 export {
   hasTTY,

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,6 +1,6 @@
 // Reference: https://github.com/watson/ci-info/blob/v3.2.0/vendors.json
 
-import { env, process } from "./env.ts";
+import { env, process } from "#env";
 
 /**
  * Represents the name of a CI/CD or Deployment provider.

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -1,4 +1,4 @@
-import { process } from "./env.ts";
+import { process } from "#env";
 
 /**
  * Represents the name of a JavaScript runtime.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitOverride": true,
     "noEmit": true,
-    "erasableSyntaxOnly": true
+    "erasableSyntaxOnly": true,
+    "types": ["node", "@cloudflare/workers-types"]
   },
   "include": ["src", "test"]
 }


### PR DESCRIPTION
- Resolves #162
- Can also try to use this approach for any runtime from [https://runtime-keys.proposal.wintercg.org](https://runtime-keys.proposal.wintercg.org/#sec-runtime-source) 

To work with this method without duplicating the code, you need to abandon building into a single file, which slightly increases the package size.

You also need to check the publishing command, you need to use `pnpm publish`, as it correctly applies `publishConfig` in `package.json`.

- Optional option to output the correct types from `cloudflare:worker`
```jsonc
// tsconfig.json
{
  "compilerOptions": {
    "customConditions": ["workerd"]
  }
}
```
```ts
// worker.ts
import {env as _env} from 'cloudflare:workers'
import {env} from 'std-env'

env satisfies Cloudflare.Env // ok
console.log(env === _env) // true
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Cloudflare Workers runtime environment.

* **Chores**
  * Updated build configuration for improved minification handling.
  * Enhanced release process with explicit package publishing.
  * Added Cloudflare Workers type definitions for development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->