### PR TITLE
fix(agents): don't detect kiro IDE integrated terminal as an agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,8 @@ All detection modules follow the same pattern:
   - `InternalAgent = [agentName: AgentName, envChecks: EnvCheck[]]`
 - Each agent maps to an array of `EnvCheck` items; the first matching check wins
 - When `EnvCheck` is a string, the env var must be truthy; when it's a function, it receives the full env object and returns a boolean
-- `envMatcher(envKey, regex)` helper creates regex-based env var matchers (e.g., `envMatcher("TERM_PROGRAM", /kiro/)`)
+- `envMatcher(envKey, regex, opts?)` helper creates regex-based env var matchers (e.g., `envMatcher("TERM_PROGRAM", /kiro/)`)
+  - `opts.noTTY: true` makes the matcher only match in a non-interactive context (when `process.stdout.isTTY` is falsy). Use for detections keyed off generic terminal env vars that an IDE sets in its integrated terminal too — e.g. `kiro` (`TERM_PROGRAM=kiro`), where a TTY means a human is at the IDE terminal, not the agent CLI (see #185)
 - IDEs (cursor, devin, kiro) are checked last so agents running inside them are detected first
 - Exports: `detectAgent()`, `agentInfo` (singleton), `agent` (name shorthand), `isAgent` (boolean)
 

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -50,11 +50,19 @@ const agents: InternalAgent[] = [
   // ✅ Verified by cursor (can be detected using CURSOR_AGENT, CURSOR_TRACE_ID, CURSOR_SANDBOX)
   ["cursor", ["CURSOR_AGENT"]],
   // ✅ Verified by kiro (can be detected using TERM_PROGRAM)
-  ["kiro", [envMatcher("TERM_PROGRAM", /kiro/)]],
+  // `TERM_PROGRAM=kiro` is set by both the Kiro IDE integrated terminal (interactive,
+  // has a TTY) and the Kiro CLI agent (non-interactive, no TTY). Gate on `noTTY` so a
+  // human typing in the IDE terminal is not mis-detected as an agent. See #185.
+  ["kiro", [envMatcher("TERM_PROGRAM", /kiro/, { noTTY: true })]],
 ];
 
-function envMatcher(envKey: string, regex: RegExp) {
+function envMatcher(envKey: string, regex: RegExp, opts?: { noTTY?: boolean }) {
   return () => {
+    // When `noTTY` is set, only match in a non-interactive (agent) context. A TTY
+    // means a human is at an integrated terminal, not an agent-spawned subprocess.
+    if (opts?.noTTY && globalThis.process?.stdout?.isTTY) {
+      return false;
+    }
     const value = env[envKey];
     return value ? regex.test(value) : false;
   };

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,6 +1,6 @@
 // Note to AI Agents: Check @AGENTS.md for instructions on how to self-verify.
 
-import { env } from "./env.ts";
+import { env, process } from "./env.ts";
 
 /**
  * Represents the name of an AI coding agent.
@@ -60,7 +60,7 @@ function envMatcher(envKey: string, regex: RegExp, opts?: { noTTY?: boolean }) {
   return () => {
     // When `noTTY` is set, only match in a non-interactive (agent) context. A TTY
     // means a human is at an integrated terminal, not an agent-spawned subprocess.
-    if (opts?.noTTY && globalThis.process?.stdout?.isTTY) {
+    if (opts?.noTTY && process.stdout?.isTTY) {
       return false;
     }
     const value = env[envKey];

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -1,5 +1,6 @@
 import { expect, it, describe, vi, beforeEach, afterEach } from "vitest";
 import { detectAgent } from "../src/agents.ts";
+import { process } from "../src/env.ts";
 
 // All env vars that agent detection may check
 const agentEnvKeys = [
@@ -22,15 +23,25 @@ const agentEnvKeys = [
 ];
 
 describe("detectAgent", () => {
+  const originalIsTTY = process.stdout?.isTTY;
+
   beforeEach(() => {
     // Clear all agent-related env vars to ensure a clean slate
     for (const key of agentEnvKeys) {
       vi.stubEnv(key, "");
     }
+    // Default to a non-interactive (agent-like) context so TTY-gated checks are
+    // deterministic regardless of how the test runner is invoked.
+    if (process.stdout) {
+      process.stdout.isTTY = false;
+    }
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
+    if (process.stdout) {
+      process.stdout.isTTY = originalIsTTY!;
+    }
   });
 
   it("returns empty object when no agent env is set", () => {
@@ -75,6 +86,14 @@ describe("detectAgent", () => {
 
     it("does not detect kiro when TERM_PROGRAM does not match", () => {
       vi.stubEnv("TERM_PROGRAM", "vscode");
+      expect(detectAgent()).toEqual({});
+    });
+
+    it("does not detect kiro when a TTY is present (IDE integrated terminal, see #185)", () => {
+      vi.stubEnv("TERM_PROGRAM", "kiro-terminal");
+      if (process.stdout) {
+        process.stdout.isTTY = true;
+      }
       expect(detectAgent()).toEqual({});
     });
 


### PR DESCRIPTION
## Problem

`std-env` cannot distinguish **Kiro IDE** (a VS Code fork, human typing in its integrated terminal) from **Kiro CLI** (the actual coding agent) — both set `TERM_PROGRAM=kiro`. As a result, a human working in the Kiro IDE terminal is wrongly reported as `isAgent: true`.

`kiro` is uniquely affected because it keys off `TERM_PROGRAM`, a **generic** terminal env var that the emulator sets regardless of who is driving — unlike `cursor`, which uses the agent-specific `CURSOR_AGENT`.

This also causes downstream fallout: vitest disables colored output when `std-env` reports an agent (vitest-dev/vitest#9851), so the false positive kills colors in the Kiro IDE terminal (vitest-dev/vitest#10053).

## Fix

Per @pi0's suggestion in #185, use a TTY check to discriminate. Added a `noTTY` option to `envMatcher`; when set, the matcher only fires in a non-interactive (agent) context (`process.stdout.isTTY` falsy). Applied it to the `kiro` entry only.

| Scenario | `TERM_PROGRAM` | TTY | `isAgent` |
| --- | --- | --- | --- |
| Kiro CLI agent runs a subprocess (e.g. vitest) | `kiro` | none | `true` ✅ |
| Human runs a command in the Kiro IDE terminal | `kiro` | yes | `false` ✅ (colors restored) |

## Verification

- Isolated self-test on the real build confirms both scenarios (`{ name: 'kiro' }` without a TTY, `{}` with one).
- Added a #185 regression test with deterministic TTY stubbing. Full suite: **24 passed**, lint + typecheck clean.
- `AGENTS.md` updated to document the new `envMatcher(..., { noTTY })` convention. The supported-agent list is unchanged, so `README.md` needs no edit.

Fixes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent environment detection to avoid false “kiro” matches in interactive/TTY terminals.
* **Documentation**
  * Updated agent detection guidance to document non-interactive matching behavior (including `noTTY: true`) and when to use it.
* **Tests**
  * Added/updated test cases to simulate TTY vs non-TTY conditions and confirm “kiro” detection does not trigger under interactive terminal scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->