### PR TITLE
feat: add isNub runtime detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ All detection modules follow the same pattern:
 - Priority order: netlify → edge-light → workerd → fastly → deno → bun → node
 - Uses global objects (e.g., `globalThis.Bun`, `globalThis.Deno`, `navigator.userAgent`)
 - `isNode` is true for Node-compatible runtimes (Bun, Deno with compat); use `runtime === "node"` for strict check
+- `isNub` (`!!process.versions.nub`) detects [Nub](https://github.com/nubjs/nub), a Node.js augmentation layer — additive, so `isNode` stays true and `runtime` stays `"node"`; it is deliberately NOT in `runtimeChecks` or `RuntimeName`
 
 ### Flags (`src/flags.ts`)
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Individual named exports: `isNode`, `isBun`, `isDeno`, `isNetlify`, `isEdgeLight
 
 > [!NOTE]
 > `isNode` is also `true` in Bun/Deno with Node.js compatibility mode. Use `runtime === "node"` for strict checks.
-
-> [!NOTE]
+>
 > `isNub` detects [Nub](https://github.com/nubjs/nub), which augments Node.js rather than replacing it. It is additive: `isNode` is also `true` and `runtime` stays `"node"`.
 
 See [./src/runtimes.ts](./src/runtimes.ts) for the full list.

--- a/README.md
+++ b/README.md
@@ -17,10 +17,13 @@ console.log(runtime); // "" | "node" | "deno" | "bun" | "workerd" ...
 console.log(runtimeInfo); // { name: "node" }
 ```
 
-Individual named exports: `isNode`, `isBun`, `isDeno`, `isNetlify`, `isEdgeLight`, `isWorkerd`, `isFastly`
+Individual named exports: `isNode`, `isBun`, `isDeno`, `isNetlify`, `isEdgeLight`, `isWorkerd`, `isFastly`, `isNub`
 
 > [!NOTE]
 > `isNode` is also `true` in Bun/Deno with Node.js compatibility mode. Use `runtime === "node"` for strict checks.
+
+> [!NOTE]
+> `isNub` detects [Nub](https://github.com/nubjs/nub), which augments Node.js rather than replacing it. It is additive: `isNode` is also `true` and `runtime` stays `"node"`.
 
 See [./src/runtimes.ts](./src/runtimes.ts) for the full list.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export {
   isBun,
   isDeno,
   isNode,
+  isNub,
   runtime,
   runtimeInfo,
   isEdgeLight,

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -32,6 +32,15 @@ export type RuntimeInfo = {
 export const isNode: boolean = !!process?.versions?.node;
 
 /**
+ * Indicates if running under [Nub](https://github.com/nubjs/nub).
+ *
+ * **Note:** Nub augments Node.js rather than replacing it, so `isNode` is also `true` and
+ * `runtime` stays `"node"`. This flag is additive — it detects the Nub augmentation layer
+ * on top of Node.
+ */
+export const isNub: boolean = !!process?.versions?.nub;
+
+/**
  * Indicates if running in Bun runtime.
  */
 export const isBun: boolean = "Bun" in globalThis;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -14,6 +14,7 @@ describe("std-env", () => {
       isProduction: false,
       isDevelopment: false,
       isMinimal: true,
+      isNub: false,
       isWindows: expect.any(Boolean),
       isLinux: expect.any(Boolean),
       isMacOS: expect.any(Boolean),


### PR DESCRIPTION
Adds `isNub` to detect [Nub](https://github.com/nubjs/nub), a CLI that augments Node.js through Node's own extension surfaces — not a separate runtime. Under Nub, `process.versions.node` is set, so detection is additive: `isNub` is `true` while `isNode` stays `true` and `runtime` stays `"node"`. It's a layer on Node, not a sibling of Bun/Deno, so it's deliberately not in `runtimeChecks` or `RuntimeName`.

The signal is `process.versions.nub`, Nub's self-identification marker (`process.versions.<runtime>` convention, cf. `.bun`, `.electron`) — mirroring `isNode = !!process?.versions?.node`. Absent under Nub's `--node`/`NODE_COMPAT` passthrough.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new runtime flag, `isNub`, to detect Nub environments.
  * Exported `isNub` from the main package entry point.

* **Documentation**
  * Updated runtime detection docs/README to include `isNub`.
  * Clarified that Nub detection is additive, so `isNode` and `runtime` remain unchanged.

* **Tests**
  * Extended the default environment test to verify `isNub` is `false` by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->