### PR TITLE
feat: detect Vitest and Jest in isTest (#124)

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -19,8 +19,9 @@ export const hasWindow: boolean = typeof window !== "undefined";
 /** Detect if `DEBUG` environment variable is set */
 export const isDebug: boolean = !!env.DEBUG;
 
-/** Detect if `NODE_ENV` environment variable is `test` or `TEST` environment variable is set */
-export const isTest: boolean = nodeENV === "test" || !!env.TEST;
+/** Detect if `NODE_ENV` environment variable is `test`, `TEST` is set, or common test runners (Vitest, Jest) are detected */
+export const isTest: boolean =
+  nodeENV === "test" || !!env.TEST || !!env.VITEST || !!env.JEST_WORKER_ID;
 
 /** Detect if `NODE_ENV` or `MODE` environment variable is `production` */
 export const isProduction: boolean = nodeENV === "production" || env.MODE === "production";


### PR DESCRIPTION
Resolves #124.

Currently `isTest` only checks `nodeENV === "test" || !!env.TEST`. When running test suites under Vitest or Jest without explicitly overriding `NODE_ENV=test`, `isTest` evaluates to `false`.

This PR expands `isTest` to check for `env.VITEST` and `env.JEST_WORKER_ID` to automatically detect execution under those test runners without pulling extra dependencies or breaking tree-shaking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Test-mode detection now recognizes Vitest and Jest worker environments, improving behavior during automated test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->